### PR TITLE
Add code of conduct and mention in readme and contributing files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+* Other unethical or unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct. By adopting this Code of Conduct, project
+maintainers commit themselves to fairly and consistently applying these
+principles to every aspect of managing this project. Project maintainers who do
+not follow or enforce the Code of Conduct may be permanently removed from the
+project team.
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by opening an issue or contacting one or more of the project
+maintainers.
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](http://contributor-covenant.org), version 1.2.0,
+available at [http://contributor- covenant.org/version/1/2/0/](http
+://contributor-covenant.org/version/1/2/0/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# CONTRIBUTING
+
+## RESOURCES
+
+If you wish to contribute to joind.in, please be sure to
+read/subscribe to the following resources:
+
+ -  Contributor Code of Conduct: https://github.com/joindin/joindin-api/CODE_OF_CONDUCT.md
+ -  Contributor's Guide:
+    https://github.com/joindin/joind.in/wiki/How-to-Contribute-Code
+ -  Contributor's mailing list:
+    http://groups.google.com/group/joindin-developers
+ -  Contributor's IRC channel:
+    #joind.in on Freenode.net

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ This README is intended to help get you started. Definitely update and improve t
 [hubot]: http://hubot.github.com
 [generator-hubot]: https://github.com/github/generator-hubot
 
+### Welcome
+
+Joind.in welcomes all contributors regardless of your ability or experience. We especially welcome
+you if you are new to Open Source development and will provide a helping hand. To ensure that
+everyone understands what we expect from our community, our projects have a [Contributor Code of
+Conduct](CODE_OF_CONDUCT.md) and by participating in the development of joind.in you agree to abide
+by its terms.
+
+
 ### Running joindin-hubot Locally
 
 You can test your hubot by running the following.


### PR DESCRIPTION
Bring in the code of conduct files to match the other projects in the organisation
